### PR TITLE
Change useragent check from lunos to LuneOS

### DIFF
--- a/LuneOS/LuneOS.js
+++ b/LuneOS/LuneOS.js
@@ -21,7 +21,7 @@
 	window.Mojo = window.Mojo || {};
 
 	// platform verification
-	if(window.navigator.userAgent.toLowerCase().indexOf('lunos')>=0) {
+	if(window.navigator.userAgent.toLowerCase().indexOf('LuneOS')>=0) {
 		webOS.platform.luneos = true;
 	}
 

--- a/LuneOS/LuneOS.js
+++ b/LuneOS/LuneOS.js
@@ -21,7 +21,7 @@
 	window.Mojo = window.Mojo || {};
 
 	// platform verification
-	if(window.navigator.userAgent.toLowerCase().indexOf('LuneOS')>=0) {
+	if(window.navigator.userAgent.toLowerCase().indexOf('luneos')>=0) {
 		webOS.platform.luneos = true;
 	}
 


### PR DESCRIPTION
I think john mcconnell cryptically pointed to this issue on webosnation: http://forums.webosnation.com/webos-development/330979-enyo-2-7-aka-2-6-legacy-luneos-2.html#post3445218
Current luneOS userAgent uses 'luneOS' : https://github.com/webOS-ports/org.webosports.app.browser/blob/master-webengine/qml/UserAgent.qml
